### PR TITLE
Readid transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - conda info -a
 
   # Create test environment and install deps
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools pip cython numpy nose pbgzip
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools pip cython numpy nose samtools
   - source activate test-environment
   - pip install click
   - python setup.py build_ext -i

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Requirements:
 
 - Python 3.x
 - Python packages `cython`, `numpy` and `click`.
-- Command-line utilities `sort` (the Unix version), `bgzip` (shipped with `tabix`)  and `samtools`. If available, `pairtools` can compress outputs with `pbgzip` and `lz4`.
+- Command-line utilities `sort` (the Unix version), `bgzip` (shipped with `samtools`)  and `samtools`. If available, `pairtools` can compress outputs with `pbgzip` and `lz4`.
 
 We highly recommend using the `conda` package manager to install `pairtools` together with all its dependencies. To get it, you can either install the full [Anaconda](https://www.continuum.io/downloads) Python distribution or just the standalone [conda](http://conda.pydata.org/miniconda.html) package manager.
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -6,8 +6,8 @@ Requirements
 
 - Python 3.x
 - Python packages `numpy` and `click`
-- Command-line utilities `sort` (the Unix version), `bgzip` (shipped with `tabix`) 
-  and `samtools`. If available, `pairtools` can compress outputs with `pbgzip` and `lz4`.
+- Command-line utilities `sort` (the Unix version), `bgzip` (shipped with `samtools`) 
+  and `samtools`. If available, `pairtools` can compress outputs with `bgzip`, `pbgzip` and `lz4`.
 
 Install using conda
 -------------------

--- a/pairtools/__init__.py
+++ b/pairtools/__init__.py
@@ -11,7 +11,7 @@ CLI tools to process mapped Hi-C data
 
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1-dev.1'
 
 
 import click

--- a/pairtools/_headerops.py
+++ b/pairtools/_headerops.py
@@ -85,6 +85,22 @@ def extract_column_names(header):
         return []
 
 
+def extract_chromsizes(header):
+    '''
+    Extract chromosome sizes from header lines.
+    '''
+    
+    chromsizes_str = pairtools._headerops.extract_fields(
+        header,
+        'chromsize')
+    chromsizes_str = list(zip(*[s.split(' ') for s in chromsizes_str]))
+    chromsizes = pd.Series(
+        data = chromsizes_str[1],
+        index = chromsizes_str[0]).astype(np.int64)
+    
+    return chromsizes
+
+
 def get_chromsizes_from_sam_header(samheader):
     SQs = [l.split('\t') for l in samheader if l.startswith('@SQ')]
     chromsizes = [(sq[1][3:], int(sq[2][3:])) for sq in SQs]

--- a/pairtools/pairtools_dedup.py
+++ b/pairtools/pairtools_dedup.py
@@ -30,14 +30,14 @@ MAX_LEN = 10000
     type=str, 
     default="", 
     help='output file for pairs after duplicate removal.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 @click.option(
     "--output-dups",
     type=str, 
     default="", 
     help='output file for duplicated pairs. '
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' If the path is the same as in --output or -, output duplicates together '
         ' with deduped pairs. By default, duplicates are dropped.')
 @click.option(
@@ -45,7 +45,7 @@ MAX_LEN = 10000
     type=str, 
     default="", 
     help='output file for unmapped pairs. '
-        'If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed. '
+        'If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed. '
         'If the path is the same as in --output or -, output unmapped pairs together '
         'with deduped pairs. If the path is the same as --output-dups, output '
         'unmapped reads together with dups. By default, unmapped pairs are dropped.')
@@ -55,7 +55,7 @@ MAX_LEN = 10000
     default="", 
     help='output file for duplicate statistics. '
         ' If file exists, it will be open in the append mode.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, statistics are not printed.')
 @click.option(
     "--max-mismatch",
@@ -153,7 +153,7 @@ def dedup(pairs_path, output, output_dups, output_unmapped,
     file. Allow for a +/-N bp mismatch at each side of duplicated molecules.
 
     PAIRS_PATH : input triu-flipped sorted .pairs or .pairsam file.  If the
-    path ends with .gz/.lz4, the input is decompressed by pbgzip/lz4c. 
+    path ends with .gz/.lz4, the input is decompressed by bgzip/lz4c. 
     By default, the input is read from stdin.
     '''
     dedup_py(pairs_path, output, output_dups, output_unmapped,

--- a/pairtools/pairtools_filterbycov.py
+++ b/pairtools/pairtools_filterbycov.py
@@ -30,14 +30,14 @@ UTIL_NAME = 'pairtools_filterbycov'
     type=str, 
     default="", 
     help='output file for pairs from low coverage regions.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 @click.option(
     "--output-highcov",
     type=str, 
     default="", 
     help='output file for pairs from high coverage regions.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' If the path is the same as in --output or -, output duplicates together '
         ' with deduped pairs. By default, duplicates are dropped.')
 @click.option(
@@ -45,7 +45,7 @@ UTIL_NAME = 'pairtools_filterbycov'
     type=str, 
     default="", 
     help='output file for unmapped pairs. '
-        'If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed. '
+        'If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed. '
         'If the path is the same as in --output or -, output unmapped pairs together '
         'with deduped pairs. If the path is the same as --output-highcov, '
         'output unmapped reads together. By default, unmapped pairs are dropped.')
@@ -55,7 +55,7 @@ UTIL_NAME = 'pairtools_filterbycov'
     default="", 
     help='output file for statistics of multiple interactors. '
         ' If file exists, it will be open in the append mode.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, statistics are not printed.')
 @click.option(
     "--max-cov",
@@ -151,7 +151,7 @@ def filterbycov(
     copy number.
 
     PAIRS_PATH : input triu-flipped sorted .pairs or .pairsam file.  If the
-    path ends with .gz/.lz4, the input is decompressed by pbgzip/lz4c. 
+    path ends with .gz/.lz4, the input is decompressed by bgzip/lz4c. 
     By default, the input is read from stdin.
     '''
     filterbycov_py(

--- a/pairtools/pairtools_flip.py
+++ b/pairtools/pairtools_flip.py
@@ -26,7 +26,7 @@ UTIL_NAME = 'pairtools_flip'
     type=str, 
     default="", 
     help='output file.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 
 @common_io_options
@@ -45,7 +45,7 @@ def flip(
     The order of chromosomes must be provided via a .chromsizes file.
 
     PAIRS_PATH : input .pairs/.pairsam file. If the path ends with .gz or .lz4, the
-    input is decompressed by pbgzip/lz4c. By default, the input is read from stdin.
+    input is decompressed by bgzip/lz4c. By default, the input is read from stdin.
 
     '''
     flip_py(

--- a/pairtools/pairtools_markasdup.py
+++ b/pairtools/pairtools_markasdup.py
@@ -18,7 +18,7 @@ UTIL_NAME = 'pairtools_markasdup'
     type=str, 
     default="", 
     help='output .pairsam file.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 
 @common_io_options

--- a/pairtools/pairtools_merge.py
+++ b/pairtools/pairtools_merge.py
@@ -21,7 +21,7 @@ UTIL_NAME = 'pairtools_merge'
     type=str, 
     default="", 
     help='output file.'
-        ' If the path ends with .gz/.lz4, the output is compressed by pbgzip/lz4c.'
+        ' If the path ends with .gz/.lz4, the output is compressed by bgzip/lz4c.'
         ' By default, the output is printed into stdout.')
 
 @click.option(
@@ -117,7 +117,7 @@ def merge(pairs_path, output, max_nmerge, tmpdir, memory, compress_program, npro
 
     PAIRS_PATH : upper-triangular flipped sorted .pairs/.pairsam files to merge
     or a group/groups of .pairs/.pairsam files specified by a wildcard. For
-    paths ending in .gz/.lz4, the files are decompressed by pbgzip/lz4c.
+    paths ending in .gz/.lz4, the files are decompressed by bgzip/lz4c.
     
     """
     merge_py(pairs_path, output, max_nmerge, tmpdir, memory, compress_program, nproc, **kwargs)
@@ -186,7 +186,7 @@ def merge_py(pairs_path, output, max_nmerge, tmpdir, memory, compress_program, n
         if kwargs.get('cmd_in', None):
             command += r''' <(cat {} | {} | sed -n -e '\''/^[^#]/,$p'\'')'''.format(path, kwargs['cmd_in'])
         elif path.endswith('.gz'):
-            command += r''' <(pbgzip -dc -n {} {} | sed -n -e '\''/^[^#]/,$p'\'')'''.format(kwargs['nproc_in'], path)
+            command += r''' <(bgzip -dc -@ {} {} | sed -n -e '\''/^[^#]/,$p'\'')'''.format(kwargs['nproc_in'], path)
         elif path.endswith('.lz4'):
             command += r''' <(lz4c -dc {} | sed -n -e '\''/^[^#]/,$p'\'')'''.format(path)
         else:

--- a/pairtools/pairtools_parse.py
+++ b/pairtools/pairtools_parse.py
@@ -138,9 +138,9 @@ EXTRA_COLUMNS = [
     "--readid-transform", 
     type=str,
     default=None,
-    help='A Python expression to modify read IDs. Useful when read ID differ '
-    'between the two reads of a pair. Must be valid Python expression that '
-    'use a variable called readID and return a new value, e.g. "readID[:-2]".',
+    help='A Python expression to modify read IDs. Useful when read IDs differ '
+    'between the two reads of a pair. Must be a valid Python expression that '
+    'uses a variable called readID and returns a new value, e.g. "readID[:-2]".',
     show_default=True
     )
 

--- a/pairtools/pairtools_parse.py
+++ b/pairtools/pairtools_parse.py
@@ -48,7 +48,7 @@ EXTRA_COLUMNS = [
     type=str, 
     default="", 
     help='output file. '
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4-compressed.'
          'By default, the output is printed into stdout. ')
 @click.option(
     "--assembly", 
@@ -94,7 +94,7 @@ EXTRA_COLUMNS = [
     help='output file for all parsed alignments, including walks.'
         ' Useful for debugging and rnalysis of walks.'
         ' If file exists, it will be open in the append mode.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4-compressed.'
         ' By default, not used.'
         )
 @click.option(

--- a/pairtools/pairtools_phase.py
+++ b/pairtools/pairtools_phase.py
@@ -17,7 +17,7 @@ UTIL_NAME = 'pairtools_phase'
     type=str, 
     default="", 
     help='output file.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 
 @click.option(
@@ -45,7 +45,7 @@ def phase(
     '''Phase pairs mapped to a diploid genome.
 
     PAIRS_PATH : input .pairs/.pairsam file. If the path ends with .gz or .lz4, the
-    input is decompressed by pbgzip/lz4c. By default, the input is read from stdin.
+    input is decompressed by bgzip/lz4c. By default, the input is read from stdin.
 
     '''
     phase_py(

--- a/pairtools/pairtools_restrict.py
+++ b/pairtools/pairtools_restrict.py
@@ -30,7 +30,7 @@ UTIL_NAME = 'pairtools_restrict'
     type=str, 
     default="", 
     help='output .pairs/.pairsam file.'
-        ' If the path ends with .gz/.lz4, the output is compressed by pbgzip/lz4c.'
+        ' If the path ends with .gz/.lz4, the output is compressed by bgzip/lz4c.'
         ' By default, the output is printed into stdout.')
 
 @common_io_options
@@ -41,7 +41,7 @@ def restrict(pairs_path, frags, output, **kwargs):
     Identify the restriction fragments that got ligated into a Hi-C molecule.
 
     PAIRS_PATH : input .pairs/.pairsam file. If the path ends with .gz/.lz4, the 
-    input is decompressed by pbgzip/lz4c. By default, the input is read from stdin.
+    input is decompressed by bgzip/lz4c. By default, the input is read from stdin.
     '''
     restrict_py(pairs_path, frags, output, **kwargs)
 

--- a/pairtools/pairtools_sample.py
+++ b/pairtools/pairtools_sample.py
@@ -24,7 +24,7 @@ UTIL_NAME = 'pairtools_sample'
     type=str, 
     default="", 
     help='output file.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 
 @click.option(
@@ -44,7 +44,7 @@ def sample(
     FRACTION: the fraction of the randomly selected pairs subset 
 
     PAIRS_PATH : input .pairs/.pairsam file. If the path ends with .gz or .lz4, the
-    input is decompressed by pbgzip/lz4c. By default, the input is read from stdin.
+    input is decompressed by bgzip/lz4c. By default, the input is read from stdin.
 
     '''
     sample_py(

--- a/pairtools/pairtools_select.py
+++ b/pairtools/pairtools_select.py
@@ -23,7 +23,7 @@ UTIL_NAME = 'pairtools_select'
     type=str, 
     default="", 
     help='output file.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, the output is printed into stdout.')
 
 @click.option(
@@ -31,7 +31,7 @@ UTIL_NAME = 'pairtools_select'
     type=str, 
     default="", 
     help='output file for pairs of other types. '
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' By default, such pairs are dropped.')
 
 @click.option(
@@ -89,7 +89,7 @@ def select(
     inside CONDITION.
 
     PAIRS_PATH : input .pairs/.pairsam file. If the path ends with .gz or .lz4, the
-    input is decompressed by pbgzip/lz4c. By default, the input is read from stdin.
+    input is decompressed by bgzip/lz4c. By default, the input is read from stdin.
 
     The following functions can be used in CONDITION besides the standard Python functions:
 

--- a/pairtools/pairtools_sort.py
+++ b/pairtools/pairtools_sort.py
@@ -23,7 +23,7 @@ UTIL_NAME = 'pairtools_sort'
     type=str, 
     default="", 
     help='output pairs file.'
-        ' If the path ends with .gz or .lz4, the output is compressed by pbgzip '
+        ' If the path ends with .gz or .lz4, the output is compressed by bgzip '
         'or lz4, correspondingly. By default, the output is printed into stdout.')
 
 @click.option(
@@ -72,7 +72,7 @@ def sort(pairs_path, output, nproc, tmpdir, memory, compress_program, **kwargs):
     pair_type.
 
     PAIRS_PATH : input .pairs/.pairsam file. If the path ends with .gz or .lz4, the 
-    input is decompressed by pbgzip or lz4c, correspondingly. By default, the 
+    input is decompressed by bgzip or lz4c, correspondingly. By default, the 
     input is read as text from stdin.
     '''
     sort_py(pairs_path, output, nproc, tmpdir, memory, compress_program, **kwargs)

--- a/pairtools/pairtools_split.py
+++ b/pairtools/pairtools_split.py
@@ -19,7 +19,7 @@ UTIL_NAME = 'pairtools_split'
     type=str, 
     default="", 
     help='output pairs file.'
-        ' If the path ends with .gz or .lz4, the output is pbgzip-/lz4c-compressed.'
+        ' If the path ends with .gz or .lz4, the output is bgzip-/lz4c-compressed.'
         ' If -, pairs are printed to stdout.'
         ' If not specified, pairs are dropped.')
 @click.option(
@@ -40,7 +40,7 @@ def split(pairsam_path, output_pairs, output_sam, **kwargs):
     a .pairs file without sam1/sam2 fields.
 
     PAIRSAM_PATH : input .pairsam file. If the path ends with .gz or .lz4, the
-    input is decompressed by pbgzip or lz4c. By default, the input is read from 
+    input is decompressed by bgzip or lz4c. By default, the input is read from 
     stdin.
     '''
     split_py(pairsam_path, output_pairs, output_sam, **kwargs)

--- a/pairtools/pairtools_stats.py
+++ b/pairtools/pairtools_stats.py
@@ -46,7 +46,7 @@ def stats(input_path, output, merge, **kwargs):
     If --merge is specified, then INPUT_PATH is interpreted as an arbitrary number 
     of stats files to merge.
     
-    The files with paths ending with .gz/.lz4 are decompressed by pbgzip/lz4c. 
+    The files with paths ending with .gz/.lz4 are decompressed by bgzip/lz4c. 
     '''
     stats_py(input_path, output, merge, **kwargs)
 


### PR DESCRIPTION
with this PR I propose to add a CLI argument --readid-transform. It accepts Python expressions that will be used to modify readIDs. One immediate use case is Illumina readIDs that contain trailing /1 and /2 to designate the two sides of a read, i.e.: 
@HWUSI-EAS100R:6:73:941:1973#0/1
vs 
@HWUSI-EAS100R:6:73:941:1973#0/2.
Currently, pairtools parse considers such reads as coming from two different read pairs and fails to parse such files.

I decided to go for a Python function to accommodate for all possible ways in which side IDs could be included into read ids. E.g. Wikipedia says that sometimes read ID can look as "@EAS139:136:FC706VJ:2:2104:15343:197393 1:N:18:1", which would require a more elaborate read transform function.

The other alternatives to deal with this issue include:
-- a binary flag, e.g. "--truncate-readid", which would remove 2 trailing characters from readid
-- an option "--truncate-readid", which would accept the number of trailing characters to be removed from the readID
-- an option "--readid-transform" that would allow choosing from a list of _predefined_ functions to modify readID. 

Please, let me know what you think!
