### PR TITLE
modify the pairtools-dedup to select the best MAPQ alignment as output of deduplication

### DIFF
--- a/pairtools/__init__.py
+++ b/pairtools/__init__.py
@@ -11,7 +11,7 @@ CLI tools to process mapped Hi-C data
 
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.0b0'
 
 
 import click

--- a/pairtools/pairtools_dedup.py
+++ b/pairtools/pairtools_dedup.py
@@ -379,6 +379,7 @@ def streaming_dedup(
                 # get min_mapq 
                 if bool(mapq1ind) and bool(mapq2ind):
                     min_mapq.append(min(int(cols[mapq1ind]), int(cols[mapq2ind])))
+                    # print(min(int(cols[mapq1ind]), int(cols[mapq2ind])))
                 else:
                     min_mapq.append(0)
                 


### PR DESCRIPTION
`pairtools dedup` outputs the first alignment of duplicates. The pull request is trying to output the best MAPQ alignment of duplicates instead of the first one. It can save some alignments when apply `pairtools filter` with MAPQ threshold after deduplication. 