### PR TITLE
Python3.10 Support

### DIFF
--- a/pairtools/pairtools_stats.py
+++ b/pairtools/pairtools_stats.py
@@ -7,7 +7,8 @@ import click
 
 import numpy as np
 
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 
 from . import _fileio, _pairsam_format, cli, _headerops, common_io_options
 

--- a/pairtools/pairtools_stats.py
+++ b/pairtools/pairtools_stats.py
@@ -1,7 +1,6 @@
 
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import io
 import sys
 import click
 


### PR DESCRIPTION
 Import Mapping from collections.abc, the collections alias was dropped in Python 3.10.