### PR TITLE
Column with annotated mismatched in parse/parse2

### DIFF
--- a/pairtools/cli/parse.py
+++ b/pairtools/cli/parse.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 import click
 import sys
 
@@ -25,6 +26,7 @@ EXTRA_COLUMNS = [
     "dist_to_5",
     "dist_to_3",
     "seq",
+    "mismatches", # Format: "{ref_letter}:{mut_letter}:{phred}:{ref_position}:{read_position}"
 ]
 
 

--- a/pairtools/cli/parse2.py
+++ b/pairtools/cli/parse2.py
@@ -25,6 +25,7 @@ EXTRA_COLUMNS = [
     "dist_to_5",
     "dist_to_3",
     "seq",
+    "mismatches" # Format: "{ref_letter}:{mut_letter}:{phred}:{ref_position}:{read_position}"
 ]
 
 

--- a/pairtools/lib/parse_pysam.pyx
+++ b/pairtools/lib/parse_pysam.pyx
@@ -91,5 +91,35 @@ cdef class AlignedSegmentPairtoolized(AlignedSegment):
                 "algn_ref_span": algn_ref_span,
                 "algn_read_span": algn_read_span,
                 "read_len": read_len,
-                "matched_bp": matched_bp,
+                "matched_bp": matched_bp
             }
+
+
+from cpython cimport array
+import cython
+cimport cython
+
+cpdef list get_mismatches_c(str seq, array.array quals, list aligned_pairs):
+    '''
+    This function takes a SAM alignment and, for every mismatch between the read and reference sequences,
+    returns a tuple (the reference bp, the read bp, PHRED quality of the bp, reference position, read position).
+    
+    Reference: https://github.com/gerlichlab/scshic_pipeline/blob/master/bin/seq_mismatches.pyx 
+    '''
+
+    cdef cython.int read_pos, ref_pos
+    cdef str orig_bp, orig_bp_upper
+    cdef list mismatches = []
+
+    for read_pos, ref_pos, orig_bp in aligned_pairs:
+        orig_bp_upper = orig_bp.upper()
+        if (seq[read_pos] != orig_bp_upper):
+            mismatches.append(
+                (orig_bp_upper,
+                 seq[read_pos],
+                 quals[read_pos],
+                 ref_pos,
+                 read_pos)
+            )
+
+    return mismatches


### PR DESCRIPTION
I utilized "MD" field of sam file and added an option to extract mismatches from the alignment pairs. Here, it is reported as additional column "mismatches" with parse/parse2. With the help of [Anton's code on scsHi-C](https://github.com/gerlichlab/scshic_pipeline/blob/master/bin/detect_s4t_mutations.py) and pysam engine to parse mismatches, it turned out to be rather simple. 

For now, the user can request to store mismatches as a separate column of .pairs file  in a comprehensive format:  "{ref_letter}:{mutated_letter}:{phred}:{ref_position}:{read_position}" (all mutations listed separated by comma). 

This column, in principle, can be converted into two important types of data: 1. number of converted pairs per alignment/pair (needed for scsHi-C); 2. nucleotide variants in your Hi-C genome, 3. mutated positions in read (might be useful for Methyl-Hi-C and related stuff). 

Example output: 

![image](https://user-images.githubusercontent.com/8100372/176815606-5f8eb167-d734-4122-b070-ddd806705503.png)

This feature, although not producing any specific analysis, is potentially very powerful. The column with mutations can be used in downstream analysis as is, although we may want to design more specific functions for pairtools in the future.

You may see that the code to support this feature is tiny and easy to support. My thinking is that we can discuss the format of "mismatches" column format, document it and add for now. 
