### PR TITLE
Modified scaling.bins_pairs_by_distance to fix error thrown by narrow distance ranges.

### DIFF
--- a/pairtools/lib/scaling.py
+++ b/pairtools/lib/scaling.py
@@ -136,6 +136,7 @@ def bins_pairs_by_distance(
     pairs_df, dist_bins, regions=None, chromsizes=None, ignore_trans=False
 ):
 
+    dist_bins = np.r_[dist_bins, np.inf]
     if regions is None:
         if chromsizes is None:
             chroms = sorted(
@@ -208,7 +209,7 @@ def bins_pairs_by_distance(
     )
 
     pairs_reduced_df["max_dist"] = np.where(
-        pairs_reduced_df["dist_bin_idx"] < len(dist_bins),
+        pairs_reduced_df["dist_bin_idx"] < len(dist_bins)-1,
         dist_bins[pairs_reduced_df["dist_bin_idx"]],
         np.iinfo(np.int64).max,
     )
@@ -220,6 +221,8 @@ def bins_pairs_by_distance(
         (pairs_reduced_df.chrom1 == pairs_reduced_df.chrom2)
         & (pairs_reduced_df.start1 == pairs_reduced_df.start2)
         & (pairs_reduced_df.end1 == pairs_reduced_df.end2)
+        & (pairs_reduced_df.min_dist > 0)
+        & (pairs_reduced_df.max_dist < np.iinfo(np.int64).max)
     )
 
     pairs_for_scaling_df = pairs_reduced_df.loc[pairs_for_scaling_mask]

--- a/pairtools/lib/scaling.py
+++ b/pairtools/lib/scaling.py
@@ -136,7 +136,7 @@ def bins_pairs_by_distance(
     pairs_df, dist_bins, regions=None, chromsizes=None, ignore_trans=False
 ):
 
-    dist_bins = np.r_[dist_bins, np.inf]
+    dist_bins = np.r_[dist_bins, np.iinfo(np.int64).max]
     if regions is None:
         if chromsizes is None:
             chroms = sorted(


### PR DESCRIPTION
Proposed fix for [this issue](https://github.com/open2c/pairtools/issues/150#issue-1439106031). 

When compared to the changes proposed, there two differences: 1) I added `np.iinfo(np.int64).max` to the end of `dist_bins` instead of `np.inf` and 2) I added two additional conditions to [this mask](https://github.com/open2c/pairtools/blob/1e8d518871113692435d93a06337a2332e356bee/pairtools/lib/scaling.py#L219) to filter out entries in the `pairs_reduced_df` dataframe that  fall outside the min and max of `dist_bins`. 

Tested the changes on HFF Micro-C and everything seems to be in order:

<img width="401" alt="Screen Shot 2022-11-07 at 11 19 31 PM" src="https://user-images.githubusercontent.com/26881078/200610941-708d3609-2f45-43ca-99e7-4dfce7c336fc.png">

The final dataframe that is returned still contains entries with `min_dist` and `max_dist` values outside of the inputted distance range but that is because of `make_empty_scaling` function called on [line 243](https://github.com/open2c/pairtools/blob/1e8d518871113692435d93a06337a2332e356bee/pairtools/lib/scaling.py#L243) reintroduces them into the dataframe. I'm assuming that this is by design and so I didn't change that behavior.

Apologies for the strange documentation in the commits. Something went wrong with the formatting.